### PR TITLE
Make assertions more based on DOM rather than text

### DIFF
--- a/exercises/A-list-of-names/list-of-names.test.js
+++ b/exercises/A-list-of-names/list-of-names.test.js
@@ -13,11 +13,21 @@ test("Check DOM resembles correct output from People Array", () => {
   target.listOfNames(people);
 
   let content = document.querySelector("#content");
+  let children = content.querySelectorAll("h1, h2");
+  expect(children.length).toBe(6);
 
-  expect(content).toContainHTML(
-    `<div id="content"><h1>Chris</h1><h2>Teacher</h2><h1>Joanna</h1><h2>Student</h2><h1>Boris</h1><h2>Prime Minister</h2></div>`
-  );
+  expectTagWithText(children[0], "h1", "Chris");
+  expectTagWithText(children[1], "h2", "Teacher");
+  expectTagWithText(children[2], "h1", "Joanna");
+  expectTagWithText(children[3], "h2", "Student");
+  expectTagWithText(children[4], "h1", "Boris");
+  expectTagWithText(children[5], "h2", "Prime Minister");
 });
+
+function expectTagWithText(element, expectedTagName, expectedText) {
+  expect(element.tagName).toEqualCaseInsensitive(expectedTagName)
+  expect(element.textContent).toEqual(expectedText);
+}
 
 test("Check DOM is empty with empty input array", () => {
   document.body.innerHTML = `<div id="content" />`;
@@ -26,5 +36,6 @@ test("Check DOM is empty with empty input array", () => {
   target.listOfNames(people);
 
   let content = document.querySelector("#content");
-  expect(content.innerHTML).toBe("");
+  let children = content.querySelectorAll("h1, h2");
+  expect(children.length).toEqual(0);
 });

--- a/exercises/F-highlight-words/highlight-words.test.js
+++ b/exercises/F-highlight-words/highlight-words.test.js
@@ -2,7 +2,22 @@
 There are some tests in this file that will help you work out if your code is working.
 */
 
+const {default: userEvent} = require("@testing-library/user-event");
+
 test("Check DOM resembles correct output for initial setup", () => {
+  // do this so students can use element.innerText which jsdom does not implement
+  Object.defineProperty(global.window.HTMLElement.prototype, "innerText", {
+    get() {
+      return this.textContent;
+    },
+    set(value) {
+      this.textContent = value;
+      if (this.tagName === "OPTION") {
+        this.value = value;
+      }
+    },
+  });
+
   document.body.innerHTML = `<div id="content" />`;
   let target = require("./script.js");
 
@@ -12,8 +27,44 @@ test("Check DOM resembles correct output for initial setup", () => {
 
   target.highlightWords(paragraph, colours);
 
-  let content = document.querySelector("#content");
-  expect(content).toContainHTML(
-    `<select><option /><option /><option /><option /></select>`
-  );
+  let options = document.querySelectorAll("select > option");
+  expect(options.length).toEqual(4);
+  expect(options[0].value) === "yellow";
+  // ...
+
+  let loremElement = findElementContaining(document, "span", "Lorem");
+  let ipsumElement = findElementContaining(document, "span", "ipsum");
+
+  // TODO: Maybe use a library to resolve CSS colours to a canonical form
+  expect(loremElement.style.backgroundColor).toEqual("");
+  expect(ipsumElement.style.backgroundColor).toEqual("");
+
+  userEvent.click(loremElement);
+  expect(loremElement.style.backgroundColor).toEqual("yellow");
+  expect(ipsumElement.style.backgroundColor).toEqual("");
+
+  userEvent.click(ipsumElement);
+  expect(loremElement.style.backgroundColor).toEqual("yellow");
+  expect(ipsumElement.style.backgroundColor).toEqual("yellow");
+
+  userEvent.click(loremElement);
+  expect(loremElement.style.backgroundColor).toEqual("");
+  expect(ipsumElement.style.backgroundColor).toEqual("yellow");
 });
+
+// I tried using XPath along the lines of:
+// document.evaluate("//span[contains(text(), 'Lorem')]", document, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null).iterateNext()
+// but it consistently returned no elements, even though this worked in the real browser.
+// Accordingly, do some brute-force searching.
+function findElementContaining(document, tagName, text) {
+  const allElements = document.querySelectorAll("*");
+  for (const element of allElements) {
+    // Skip non-matching tags, because textContent is recursive.
+    if (element.tagName.toLowerCase() !== tagName) {
+      continue;
+    }
+    if (element.textContent.includes(text)) {
+      return element;
+    }
+  }
+}

--- a/exercises/F-highlight-words/script.js
+++ b/exercises/F-highlight-words/script.js
@@ -4,7 +4,11 @@ function updateColour(event) {
   const targetedSpan = event.target;
   const selectMenu = document.querySelector("select");
   const currentColour = selectMenu.value;
-  targetedSpan.style.backgroundColor = currentColour;
+  if (targetedSpan.style.backgroundColor === currentColour) {
+    targetedSpan.style.backgroundColor = "";
+  } else {
+    targetedSpan.style.backgroundColor = currentColour;
+  }
 }
 
 function highlightWords(paragraph, colours) {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/CodeYourFuture/JavaScript-Core-2-Coursework-Week2#readme",
   "devDependencies": {
     "@testing-library/jest-dom": "^5.14.1",
+    "@testing-library/user-event": "^13.1.9",
     "jest": "^26.6.3",
     "jest-extended": "^0.11.5"
   }


### PR DESCRIPTION
I created a PR as I was experimenting with some stuff and figured it was worth writing down exactly what I'd captured - I'm not necessarily suggesting we make exactly these changes, but the general idea is worth discussion.

A similar idea can be applied to all of the tests. I'm slightly torn
here - what is already here works for how our trainees are likely to
solve these problems, but the tests are quite brittle and I probably
wouldn't be happy with them IRL (because they wouldn't account for e.g.
wrapping divs around elements, extra properties in-line as the code
changes, newlines in the generated code, etc).